### PR TITLE
fix memory leak, tweaks

### DIFF
--- a/FSEventsFix.c
+++ b/FSEventsFix.c
@@ -382,65 +382,65 @@ static char *FSEventsFix_realpath_wrapper(const char * __restrict src, char * __
 // since the resolution happens entirely behind the scenes to us in CFURL.
 static char* CFURL_realpath(const char *file_name, char resolved_name[PATH_MAX])
 {
-  char* resolved;
-  CFURLRef url1;
-  CFURLRef url2;
-  CFStringRef path;
+    char* resolved;
+    CFURLRef url1;
+    CFURLRef url2;
+    CFStringRef path;
 
-  if (file_name == NULL) {
-    errno = EINVAL;
-    return (NULL);
-  }
+    if (file_name == NULL) {
+        errno = EINVAL;
+        return (NULL);
+    }
 
-  #if __DARWIN_UNIX03
-  	if (*file_name == 0) {
-  		errno = ENOENT;
-  		return (NULL);
-  	}
-  #endif
+#if __DARWIN_UNIX03
+    if (*file_name == 0) {
+        errno = ENOENT;
+        return (NULL);
+    }
+#endif
 
-  // create a buffer to store our result if we weren't passed one
-  if (!resolved_name) {
-    if ((resolved = malloc(PATH_MAX)) == NULL) return (NULL);
-  } else {
-    resolved = resolved_name;
-  }
+    // create a buffer to store our result if we weren't passed one
+    if (!resolved_name) {
+        if ((resolved = malloc(PATH_MAX)) == NULL) return (NULL);
+    } else {
+        resolved = resolved_name;
+    }
 
-  url1 = CFURLCreateFromFileSystemRepresentation(NULL, (const UInt8*)file_name, (CFIndex)strlen(file_name), false);
-  if (url1 == NULL) { goto error_return; }
+    url1 = CFURLCreateFromFileSystemRepresentation(NULL, (const UInt8*)file_name, (CFIndex)strlen(file_name), false);
+    if (url1 == NULL) { goto error_return; }
 
-  url2 = CFURLCopyAbsoluteURL(url1);
-  CFRelease(url1);
-  if (url2 == NULL) { goto error_return; }
+    url2 = CFURLCopyAbsoluteURL(url1);
+    CFRelease(url1);
+    if (url2 == NULL) { goto error_return; }
 
-  url1 = CFURLCreateFileReferenceURL(NULL, url2, NULL);
-  CFRelease(url2);
-  if (url1 == NULL) { goto error_return; }
+    url1 = CFURLCreateFileReferenceURL(NULL, url2, NULL);
+    CFRelease(url2);
+    if (url1 == NULL) { goto error_return; }
 
-  // if there are multiple hard links to the original path, this may end up
-  // being _completely_ different from what was intended
-  url2 = CFURLCreateFilePathURL(NULL, url1, NULL);
-  CFRelease(url1);
-  if (url2 == NULL) { goto error_return; }
+    // if there are multiple hard links to the original path, this may end up
+    // being _completely_ different from what was intended
+    url2 = CFURLCreateFilePathURL(NULL, url1, NULL);
+    CFRelease(url1);
+    if (url2 == NULL) { goto error_return; }
 
-  path = CFURLCopyFileSystemPath(url2, kCFURLPOSIXPathStyle);
-  CFRelease(url2);
-  if (path == NULL) { goto error_return; }
+    path = CFURLCopyFileSystemPath(url2, kCFURLPOSIXPathStyle);
+    CFRelease(url2);
+    if (path == NULL) { goto error_return; }
 
-  bool success = CFStringGetCString(path, resolved, PATH_MAX, kCFStringEncodingUTF8);
-  CFRelease(path);
-  if (!success) { goto error_return; }
+    bool success = CFStringGetCString(path, resolved, PATH_MAX, kCFStringEncodingUTF8);
+    CFRelease(path);
+    if (!success) { goto error_return; }
 
-  return resolved;
+    return resolved;
 
 error_return:
-  if (!resolved_name) {
-    // we weren't passed in an output buffer and created our own. free it
-    int e = errno;
-    free(resolved);
-    errno = e;
-  }
-  return (NULL);
+    if (!resolved_name) {
+        // we weren't passed in an output buffer and created our own. free it
+        int e = errno;
+        free(resolved);
+        errno = e;
+    }
+    return (NULL);
 }
 
 

--- a/FSEventsFix.c
+++ b/FSEventsFix.c
@@ -131,7 +131,7 @@ typedef struct {
 } rebinding_t;
 
 static rebinding_t g_rebindings[] = {
-    { "_realpath$DARWIN_EXTSN", (void *) &FSEventsFix_realpath_wrapper, (void *) &realpath }
+    { "_realpath$DARWIN_EXTSN", (void *) &FSEventsFix_realpath_wrapper, (void *) &realpath, 0 }
 };
 static const uint g_rebindings_nel = sizeof(g_rebindings) / sizeof(g_rebindings[0]);
 
@@ -361,7 +361,7 @@ static char *FSEventsFix_realpath_wrapper(const char * __restrict src, char * __
         char *result = rv ?: dst;
         if (result) {
             for (char *pch = result; *pch; ++pch) {
-                *pch = toupper(*pch);
+                *pch = (char)toupper(*pch);
             }
         }
     }
@@ -427,12 +427,9 @@ static char* CFURL_realpath(const char *file_name, char resolved_name[PATH_MAX])
   CFRelease(url2);
   if (path == NULL) { goto error_return; }
 
-  if (CFStringGetCString(path, resolved, PATH_MAX, kCFStringEncodingUTF8)) {
-    CFRelease(path);
-  } else {
-    // unable to convert? path too long? not a clue.
-    goto error_return;
-  }
+  bool success = CFStringGetCString(path, resolved, PATH_MAX, kCFStringEncodingUTF8);
+  CFRelease(path);
+  if (!success) { goto error_return; }
 
   return resolved;
 

--- a/FSEventsFix.c
+++ b/FSEventsFix.c
@@ -98,7 +98,7 @@
 #include <dlfcn.h>
 
 
-const char *const FSEventsFixVersionString = "0.10.0";
+const char *const FSEventsFixVersionString = "0.11.0";
 
 
 #pragma mark - Forward declarations

--- a/FSEventsFix.c
+++ b/FSEventsFix.c
@@ -95,14 +95,17 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <dlfcn.h>
+
 
 const char *const FSEventsFixVersionString = "0.10.0";
 
 
 #pragma mark - Forward declarations
 
-static char *FSEventsFix_realpath(const char *__restrict path, char *__restrict inresolved);
-static char *FSEventsFix_realpath_wrapper(const char *__restrict src, char * __restrict dst);
+static char *(*orig_realpath)(const char *restrict file_name, char resolved_name[PATH_MAX]);
+static char *CFURL_realpath(const char *restrict file_name, char resolved_name[PATH_MAX]);
+static char *FSEventsFix_realpath_wrapper(const char *restrict src, char *restrict dst);
 
 static void _FSEventsFixHookInstall();
 static void _FSEventsFixHookUninstall();
@@ -128,7 +131,7 @@ typedef struct {
 } rebinding_t;
 
 static rebinding_t g_rebindings[] = {
-    { "_realpath$DARWIN_EXTSN", (void *) &FSEventsFix_realpath_wrapper, NULL }
+    { "_realpath$DARWIN_EXTSN", (void *) &FSEventsFix_realpath_wrapper, (void *) &realpath }
 };
 static const uint g_rebindings_nel = sizeof(g_rebindings) / sizeof(g_rebindings[0]);
 
@@ -144,7 +147,7 @@ static void _FSEventsFixLog(FSEventsFixMessageType type, const char *__restrict 
         va_start(va, fmt);
         vasprintf(&message, fmt, va);
         va_end(va);
-        
+
         if (message) {
             if (!!(g_debug_opt & FSEventsFixDebugOptionLogToStderr)) {
                 fprintf(stderr, "FSEventsFix: %s\n", message);
@@ -189,6 +192,7 @@ void FSEventsFixEnable() {
     _FSEventsFixInitialize();
     dispatch_sync(g_queue, ^{
         if (++g_enable_refcount == 1) {
+            orig_realpath = dlsym(RTLD_DEFAULT, "realpath");
             _FSEventsFixHookInstall();
             _FSEventsFixSelfTest();
             if (g_hook_operational) {
@@ -245,7 +249,7 @@ bool _FSEventsFixIsBroken_noresolve(const char *resolved) {
 }
 
 bool FSEventsFixIsBroken(const char *path) {
-    char *resolved = FSEventsFix_realpath(path, NULL);
+    char *resolved = CFURL_realpath(path, NULL);
     if (!resolved) {
         return true;
     }
@@ -260,7 +264,7 @@ char *FSEventsFixCopyRootBrokenFolderPath(const char *inpath) {
     }
 
     // get a mutable copy of an absolute path
-    char *path = FSEventsFix_realpath(inpath, NULL);
+    char *path = CFURL_realpath(inpath, NULL);
     if (!path) {
         return NULL;
     }
@@ -340,7 +344,13 @@ static char *FSEventsFix_realpath_wrapper(const char * __restrict src, char * __
         }
     }
 
-    char *rv = FSEventsFix_realpath(src, dst);
+    // CFURL_realpath doesn't support putting where resolution failed into the
+    // dst buffer, so we call the original realpath here first and if it gets a
+    // result, replace that with the output of CFURL_realpath. that way all the
+    // features of the original realpath are available.
+    char *rv = NULL;
+    char *orv = orig_realpath(src, dst);
+    if (orv != NULL) { rv = CFURL_realpath(src, dst); }
 
     if (!!(g_debug_opt & FSEventsFixDebugOptionLogCalls)) {
         char *result = rv ?: dst;
@@ -355,377 +365,86 @@ static char *FSEventsFix_realpath_wrapper(const char * __restrict src, char * __
             }
         }
     }
-    
+
     return rv;
 }
 
 
 #pragma mark - realpath
 
-/* Copied from http://www.opensource.apple.com/source/Libc/Libc-1044.1.2/stdlib/FreeBSD/realpath.c */
-/*
- * Copyright (c) 2003 Constantin S. Svintsoff <kostik@iclub.nsu.ru>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. The names of the authors may not be used to endorse or promote
- *    products derived from this software without specific prior written
- *    permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
-
-#include <sys/cdefs.h>
-
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/mount.h>
-
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/attr.h>
-#include <sys/vnode.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-compare"
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wconditional-uninitialized"
-
-struct attrs {
-    u_int32_t len;
-    attrreference_t name;
-    dev_t dev;
-    fsobj_type_t type;
-    fsobj_id_t id;
-    char buf[PATH_MAX];
-};
-
-static const struct attrlist _rp_alist = {
-    ATTR_BIT_MAP_COUNT,
-    0,
-    ATTR_CMN_NAME | ATTR_CMN_DEVID | ATTR_CMN_OBJTYPE | ATTR_CMN_OBJID,
-    0,
-    0,
-    0,
-    0,
-};
-
-/*
- * char *realpath(const char *path, char resolved[PATH_MAX]);
- *
- * Find the real name of path, by removing all ".", ".." and symlink
- * components.  Returns (resolved) on success, or (NULL) on failure,
- * in which case the path which caused trouble is left in (resolved).
- */
-static char *
-FSEventsFix_realpath(const char *__restrict path, char inresolved[PATH_MAX])
+// naive implementation of realpath on top of CFURL
+// NOTE: doesn't quite support the full range of errno results one would
+// expect here, in part because some of these functions just return a boolean,
+// and in part because i'm not dealing with messy CFErrorRef objects and
+// attempting to translate those to sane errno values.
+// NOTE: the OSX realpath will return _where_ resolution failed in resolved_name
+// if passed in and return NULL. we can't properly support that extension here
+// since the resolution happens entirely behind the scenes to us in CFURL.
+static char* CFURL_realpath(const char *file_name, char resolved_name[PATH_MAX])
 {
-    struct attrs attrs;
-    struct stat sb;
-    char *p, *q, *s;
-    size_t left_len, resolved_len, save_resolved_len;
-    unsigned symlinks;
-    int serrno, slen, useattrs, islink;
-    char left[PATH_MAX], next_token[PATH_MAX], symlink[PATH_MAX];
-    dev_t dev, lastdev;
-    struct statfs sfs;
-    static dev_t rootdev;
-    static int rootdev_inited = 0;
-    ino_t inode;
-    char *resolved;
-    
-    if (path == NULL) {
-        errno = EINVAL;
-        return (NULL);
-    }
-#if __DARWIN_UNIX03
-    if (*path == 0) {
-        errno = ENOENT;
-        return (NULL);
-    }
-#endif /* __DARWIN_UNIX03 */
-    /*
-     * Extension to the standard; if inresolved == NULL, allocate memory
-     */
-    if (!inresolved) {
-        if ((resolved = malloc(PATH_MAX)) == NULL) return (NULL);
-    } else {
-        resolved = inresolved;
-    }
-    if (!rootdev_inited) {
-        rootdev_inited = 1;
-        if (stat("/", &sb) < 0) {
-        error_return:
-            if (!inresolved) {
-                int e = errno;
-                free(resolved);
-                errno = e;
-            }
-            return (NULL);
-        }
-        rootdev = sb.st_dev;
-    }
-    serrno = errno;
-    symlinks = 0;
-    if (path[0] == '/') {
-        resolved[0] = '/';
-        resolved[1] = '\0';
-        if (path[1] == '\0') {
-            return (resolved);
-        }
-        resolved_len = 1;
-        left_len = strlcpy(left, path + 1, sizeof(left));
-    } else {
-        if (getcwd(resolved, PATH_MAX) == NULL)
-        {
-            strlcpy(resolved, ".", PATH_MAX);
-            goto error_return;
-        }
-        resolved_len = strlen(resolved);
-        left_len = strlcpy(left, path, sizeof(left));
-    }
-    if (left_len >= sizeof(left) || resolved_len >= PATH_MAX) {
-        errno = ENAMETOOLONG;
-        goto error_return;
-    }
-    if (resolved_len > 1) {
-        if (stat(resolved, &sb) < 0) {
-            goto error_return;
-        }
-        lastdev = sb.st_dev;
-    } else
-        lastdev = rootdev;
-    
-    /*
-     * Iterate over path components in `left'.
-     */
-    while (left_len != 0) {
-        /*
-         * Extract the next path component and adjust `left'
-         * and its length.
-         */
-        p = strchr(left, '/');
-        s = p ? p : left + left_len;
-        if (s - left >= sizeof(next_token)) {
-            errno = ENAMETOOLONG;
-            goto error_return;
-        }
-        memcpy(next_token, left, s - left);
-        next_token[s - left] = '\0';
-        left_len -= s - left;
-        if (p != NULL)
-            memmove(left, s + 1, left_len + 1);
-        if (resolved[resolved_len - 1] != '/') {
-            if (resolved_len + 1 >= PATH_MAX) {
-                errno = ENAMETOOLONG;
-                goto error_return;
-            }
-            resolved[resolved_len++] = '/';
-            resolved[resolved_len] = '\0';
-        }
-        if (next_token[0] == '\0')
-            continue;
-        else if (strcmp(next_token, ".") == 0)
-            continue;
-        else if (strcmp(next_token, "..") == 0) {
-            /*
-             * Strip the last path component except when we have
-             * single "/"
-             */
-            if (resolved_len > 1) {
-                resolved[resolved_len - 1] = '\0';
-                q = strrchr(resolved, '/') + 1;
-                *q = '\0';
-                resolved_len = q - resolved;
-            }
-            continue;
-        }
-        
-        /*
-         * Save resolved_len, so that we can later null out
-         * the the appended next_token, and replace with the
-         * real name (matters on case-insensitive filesystems).
-         */
-        save_resolved_len = resolved_len;
-        
-        /*
-         * Append the next path component and lstat() it. If
-         * lstat() fails we still can return successfully if
-         * there are no more path components left.
-         */
-        resolved_len = strlcat(resolved, next_token, PATH_MAX);
-        if (resolved_len >= PATH_MAX) {
-            errno = ENAMETOOLONG;
-            goto error_return;
-        }
-        if (getattrlist(resolved, (void *)&_rp_alist, &attrs, sizeof(attrs), FSOPT_NOFOLLOW) == 0) {
-            useattrs = 1;
-            islink = (attrs.type == VLNK);
-            dev = attrs.dev;
-            inode = attrs.id.fid_objno;
-        } else if (errno == ENOTSUP || errno == EINVAL) {
-            if ((useattrs = lstat(resolved, &sb)) == 0) {
-                islink = S_ISLNK(sb.st_mode);
-                dev = sb.st_dev;
-                inode = sb.st_ino;
-            }
-        } else
-            useattrs = -1;
-        if (useattrs < 0) {
-#if !__DARWIN_UNIX03
-            if (errno == ENOENT && p == NULL) {
-                errno = serrno;
-                return (resolved);
-            }
-#endif /* !__DARWIN_UNIX03 */
-            goto error_return;
-        }
-        if (dev != lastdev) {
-            /*
-             * We have crossed a mountpoint.  For volumes like UDF
-             * the getattrlist name may not match the actual
-             * mountpoint, so we just copy the mountpoint directly.
-             * (3703138).  However, the mountpoint may not be
-             * accessible, as when chroot-ed, so check first.
-             * There may be a file on the chroot-ed volume with
-             * the same name as the mountpoint, so compare device
-             * and inode numbers.
-             */
-            lastdev = dev;
-            if (statfs(resolved, &sfs) == 0 && lstat(sfs.f_mntonname, &sb) == 0 && dev == sb.st_dev && inode == sb.st_ino) {
-                /*
-                 * However, it's possible that the mountpoint
-                 * path matches, even though it isn't the real
-                 * path in the chroot-ed environment, so check
-                 * that each component of the mountpoint
-                 * is a directory (and not a symlink)
-                 */
-                char temp[sizeof(sfs.f_mntonname)];
-                char *cp;
-                int ok = 1;
-                
-                strcpy(temp, sfs.f_mntonname);
-                for(;;) {
-                    if ((cp = strrchr(temp, '/')) == NULL) {
-                        ok = 0;
-                        break;
-                    }
-                    if (cp <= temp)
-                        break;
-                    *cp = 0;
-                    if (lstat(temp, &sb) < 0 || (sb.st_mode & S_IFMT) != S_IFDIR) {
-                        ok = 0;
-                        break;
-                    }
-                }
-                if (ok) {
-                    resolved_len = strlcpy(resolved, sfs.f_mntonname, PATH_MAX);
-                    continue;
-                }
-            }
-            /* if we fail, use the other methods. */
-        }
-        if (islink) {
-            if (symlinks++ > MAXSYMLINKS) {
-                errno = ELOOP;
-                goto error_return;
-            }
-            slen = readlink(resolved, symlink, sizeof(symlink) - 1);
-            if (slen < 0) {
-                goto error_return;
-            }
-            symlink[slen] = '\0';
-            if (symlink[0] == '/') {
-                resolved[1] = 0;
-                resolved_len = 1;
-                lastdev = rootdev;
-            } else if (resolved_len > 1) {
-                /* Strip the last path component. */
-                resolved[resolved_len - 1] = '\0';
-                q = strrchr(resolved, '/') + 1;
-                *q = '\0';
-                resolved_len = q - resolved;
-            }
-            
-            /*
-             * If there are any path components left, then
-             * append them to symlink. The result is placed
-             * in `left'.
-             */
-            if (p != NULL) {
-                if (symlink[slen - 1] != '/') {
-                    if (slen + 1 >= sizeof(symlink)) {
-                        errno = ENAMETOOLONG;
-                        goto error_return;
-                    }
-                    symlink[slen] = '/';
-                    symlink[slen + 1] = 0;
-                }
-                left_len = strlcat(symlink, left, sizeof(symlink));
-                if (left_len >= sizeof(left)) {
-                    errno = ENAMETOOLONG;
-                    goto error_return;
-                }
-            }
-            left_len = strlcpy(left, symlink, sizeof(left));
-        } else if (useattrs) {
-            /*
-             * attrs already has the real name.
-             */
-            
-            // BEGIN WORKAROUND FOR OS X BUG
-#if 0
-            resolved[save_resolved_len] = '\0';
-            resolved_len = strlcat(resolved, (const char *)&attrs.name + attrs.name.attr_dataoffset, PATH_MAX);
-            if (resolved_len >= PATH_MAX) {
-                errno = ENAMETOOLONG;
-                goto error_return;
-            }
-#endif
-            // END WORKAROUND FOR OS X BUG
-        }
-        /*
-         * For the case of useattrs == 0, we could scan the directory
-         * and try to match the inode.  There are many problems with
-         * this: (1) the directory may not be readable, (2) for multiple
-         * hard links, we would find the first, but not necessarily
-         * the one specified in the path, (3) we can't try to do
-         * a case-insensitive search to match the right one in (2),
-         * because the underlying filesystem may do things like
-         * decompose composed characters.  For most cases, doing
-         * nothing is the right thing when useattrs == 0, so we punt
-         * for now.
-         */
-    }
-    
-    /*
-     * Remove trailing slash except when the resolved pathname
-     * is a single "/".
-     */
-    if (resolved_len > 1 && resolved[resolved_len - 1] == '/')
-        resolved[resolved_len - 1] = '\0';
-    return (resolved);
-}
+  char* resolved;
+  CFURLRef url1;
+  CFURLRef url2;
+  CFStringRef path;
 
-#pragma clang diagnostic pop
+  if (file_name == NULL) {
+    errno = EINVAL;
+    return (NULL);
+  }
+
+  #if __DARWIN_UNIX03
+  	if (*file_name == 0) {
+  		errno = ENOENT;
+  		return (NULL);
+  	}
+  #endif
+
+  // create a buffer to store our result if we weren't passed one
+  if (!resolved_name) {
+    if ((resolved = malloc(PATH_MAX)) == NULL) return (NULL);
+  } else {
+    resolved = resolved_name;
+  }
+
+  url1 = CFURLCreateFromFileSystemRepresentation(NULL, (const UInt8*)file_name, (CFIndex)strlen(file_name), false);
+  if (url1 == NULL) { goto error_return; }
+
+  url2 = CFURLCopyAbsoluteURL(url1);
+  CFRelease(url1);
+  if (url2 == NULL) { goto error_return; }
+
+  url1 = CFURLCreateFileReferenceURL(NULL, url2, NULL);
+  CFRelease(url2);
+  if (url1 == NULL) { goto error_return; }
+
+  // if there are multiple hard links to the original path, this may end up
+  // being _completely_ different from what was intended
+  url2 = CFURLCreateFilePathURL(NULL, url1, NULL);
+  CFRelease(url1);
+  if (url2 == NULL) { goto error_return; }
+
+  path = CFURLCopyFileSystemPath(url2, kCFURLPOSIXPathStyle);
+  CFRelease(url2);
+  if (path == NULL) { goto error_return; }
+
+  if (CFStringGetCString(path, resolved, PATH_MAX, kCFStringEncodingUTF8)) {
+    CFRelease(path);
+  } else {
+    // unable to convert? path too long? not a clue.
+    goto error_return;
+  }
+
+  return resolved;
+
+error_return:
+  if (!resolved_name) {
+    // we weren't passed in an output buffer and created our own. free it
+    int e = errno;
+    free(resolved);
+    errno = e;
+  }
+  return (NULL);
+}
 
 
 #pragma mark - fishhook
@@ -753,7 +472,6 @@ FSEventsFix_realpath(const char *__restrict path, char inresolved[PATH_MAX])
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#import <dlfcn.h>
 #import <stdlib.h>
 #import <string.h>
 #import <sys/types.h>
@@ -816,12 +534,12 @@ static void _FSEventsFixHookUpdateImage(const struct mach_header *header, intptr
     if (dladdr(header, &info) == 0) {
         return;
     }
-    
+
     segment_command_t *cur_seg_cmd;
     segment_command_t *linkedit_segment = NULL;
     struct symtab_command* symtab_cmd = NULL;
     struct dysymtab_command* dysymtab_cmd = NULL;
-    
+
     uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
     for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
         cur_seg_cmd = (segment_command_t *)cur;
@@ -835,20 +553,20 @@ static void _FSEventsFixHookUpdateImage(const struct mach_header *header, intptr
             dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
         }
     }
-    
+
     if (!symtab_cmd || !dysymtab_cmd || !linkedit_segment ||
         !dysymtab_cmd->nindirectsyms) {
         return;
     }
-    
+
     // Find base symbol/string table addresses
     uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
     nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
     char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
-    
+
     // Get indirect symbol table (array of uint32_t indices into symbol table)
     uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
-    
+
     cur = (uintptr_t)header + sizeof(mach_header_t);
     for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
         cur_seg_cmd = (segment_command_t *)cur;
@@ -889,7 +607,7 @@ static void _FSEventsFixHookUpdate() {
 
 static void _FSEventsFixHookInstall() {
     static bool first_rebinding_done = false;
-    
+
     if (!g_hook_installed) {
         g_hook_installed = true;
 


### PR DESCRIPTION
I'm not sure why github wants to include the first CFURL realpath commit here in the pull request...

Anyways, that implementation had a small potential memory leak, which i've fixed here. I've also silenced two more clang warnings and made the indentation of my function consistent with the rest of the file.

I also bumped the version number since this is radically different from the previous approach. 
